### PR TITLE
add ajax timeout support

### DIFF
--- a/livingdoc-confluence5-plugin/src/main/java/info/novatec/testit/livingdoc/confluence/LivingDocServerConfigurationActivator.java
+++ b/livingdoc-confluence5-plugin/src/main/java/info/novatec/testit/livingdoc/confluence/LivingDocServerConfigurationActivator.java
@@ -70,6 +70,7 @@ import info.novatec.testit.livingdoc.server.rpc.xmlrpc.LivingDocXmlRpcServer;
  */
 public class LivingDocServerConfigurationActivator implements InitializingBean, DisposableBean {
     private static final Logger log = LoggerFactory.getLogger(LivingDocServerConfigurationActivator.class);
+    private static final String EXECUTION_TIMEOUT_DEFAULT = "60";
 
     private final BandanaContext bandanaContext = new ConfluenceBandanaContext("_LIVINGDOC");
 
@@ -138,6 +139,9 @@ public class LivingDocServerConfigurationActivator implements InitializingBean, 
             Properties properties = customConfiguration.getProperties();
 
             properties.setProperty("confluence.home", getConfluenceHome());
+            if(properties.getProperty("executionTimeout")==null){
+                properties.setProperty("executionTimeout", EXECUTION_TIMEOUT_DEFAULT);
+            }
 
             HibernateSessionService sessionService = new HibernateSessionService(properties);
 

--- a/livingdoc-confluence5-plugin/src/main/java/info/novatec/testit/livingdoc/confluence/actions/AbstractLivingDocAction.java
+++ b/livingdoc-confluence5-plugin/src/main/java/info/novatec/testit/livingdoc/confluence/actions/AbstractLivingDocAction.java
@@ -1,6 +1,5 @@
 package info.novatec.testit.livingdoc.confluence.actions;
 
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 import com.atlassian.confluence.core.ConfluenceActionSupport;
@@ -72,7 +71,7 @@ public abstract class AbstractLivingDocAction extends ConfluenceActionSupport {
         return this.pageId;
     }
 
-    public void setPageId(Long pageId) throws UnsupportedEncodingException {
+    public void setPageId(Long pageId) {
         page = ldUtil.getPageManager().getPage(pageId);
         this.pageId = pageId;
     }
@@ -101,8 +100,8 @@ public abstract class AbstractLivingDocAction extends ConfluenceActionSupport {
         return pageConent;
     }
 
-    public List<Page> getPermittedChildren(Page page) {
-        return ldUtil.getContentPermissionManager().getPermittedChildren(page, getAuthenticatedUser());
+    public List<Page> getPermittedChildren(Page parentPage) {
+        return ldUtil.getContentPermissionManager().getPermittedChildren(parentPage, getAuthenticatedUser());
     }
 
     @Override
@@ -112,8 +111,9 @@ public abstract class AbstractLivingDocAction extends ConfluenceActionSupport {
     }
 
     public boolean getCanEdit() {
-        if (canEdit != null)
+        if (canEdit != null) {
             return canEdit;
+        }
         canEdit = ldUtil.canEdit(page);
         return canEdit;
     }
@@ -124,7 +124,12 @@ public abstract class AbstractLivingDocAction extends ConfluenceActionSupport {
 
     @Override
     public void addActionError(String msg) {
-        if ( ! hasActionErrors())
+        if ( ! hasActionErrors()) {
             super.addActionError(msg);
+        }
+    }
+
+    public String getExecutionTimeout() {
+        return ldUtil.getLDServerConfigurationActivator().getConfiguration().getProperties().getProperty("executionTimeout");
     }
 }

--- a/livingdoc-confluence5-plugin/src/main/java/info/novatec/testit/livingdoc/confluence/actions/server/ConfigurationAction.java
+++ b/livingdoc-confluence5-plugin/src/main/java/info/novatec/testit/livingdoc/confluence/actions/server/ConfigurationAction.java
@@ -11,6 +11,7 @@ import com.atlassian.confluence.spaces.Space;
 import com.atlassian.confluence.spaces.SpaceType;
 import com.atlassian.confluence.spaces.SpacesQuery;
 
+import info.novatec.testit.livingdoc.confluence.LivingDocServerConfiguration;
 import info.novatec.testit.livingdoc.confluence.velocity.ConfluenceLivingDoc;
 import info.novatec.testit.livingdoc.server.LivingDocServerException;
 import info.novatec.testit.livingdoc.server.domain.ClasspathSet;
@@ -43,19 +44,21 @@ public class ConfigurationAction extends LivingDocServerAction {
 
     private boolean secured;
     private boolean addMode;
+    private boolean editMode = false;
     private boolean editPropertiesMode;
     private boolean editClasspathsMode;
 
     public List<Space> getSpaces() {
         // NT - Fix for getting all Spaces
-        ListBuilder<Space> lbGlobalSpace = ldUtil.getSpaceManager().getSpaces(SpacesQuery.newQuery().withSpaceType(
-            SpaceType.GLOBAL).build());
+        ListBuilder<Space> lbGlobalSpace =
+            ldUtil.getSpaceManager().getSpaces(SpacesQuery.newQuery().withSpaceType(SpaceType.GLOBAL).build());
         return lbGlobalSpace.getRange(0, lbGlobalSpace.getAvailableSize() - 1);
     }
 
     public String getConfiguration() {
-        if (isServerReady())
+        if (isServerReady()) {
             doGetRunners();
+        }
         return SUCCESS;
     }
 
@@ -64,8 +67,9 @@ public class ConfigurationAction extends LivingDocServerAction {
     }
 
     public String updateConfiguration() {
-        if (isServerReady())
+        if (isServerReady()) {
             doGetRunners();
+        }
         return SUCCESS;
     }
 
@@ -177,8 +181,8 @@ public class ConfigurationAction extends LivingDocServerAction {
 
     public String getClasspathsAsTextAreaContent() {
         StringBuilder sb = new StringBuilder();
-        for (String classpath : getClasspaths()) {
-            sb.append(classpath);
+        for (String path : getClasspaths()) {
+            sb.append(path);
             sb.append("\r");
         }
         return sb.toString();
@@ -278,6 +282,24 @@ public class ConfigurationAction extends LivingDocServerAction {
 
     public String getNewCmdLineTemplate() {
         return newCmdLineTemplate;
+    }
+
+    public String getExecutionTimeout() {
+        return ldUtil.getLDServerConfigurationActivator().getConfiguration().getProperties().getProperty("executionTimeout");
+    }
+
+    public void setExecutionTimeout(String executionTimeout) {
+        LivingDocServerConfiguration conf = ldUtil.getLDServerConfigurationActivator().getConfiguration();
+        conf.getProperties().setProperty("executionTimeout", executionTimeout);
+        ldUtil.getLDServerConfigurationActivator().storeConfiguration(conf);
+    }
+
+    public boolean isEditMode() {
+        return editMode;
+    }
+
+    public void setEditMode(boolean editMode) {
+        this.editMode = editMode;
     }
 
     private void successfullAction() {

--- a/livingdoc-confluence5-plugin/src/main/java/info/novatec/testit/livingdoc/confluence/actions/server/LivingDocServerAction.java
+++ b/livingdoc-confluence5-plugin/src/main/java/info/novatec/testit/livingdoc/confluence/actions/server/LivingDocServerAction.java
@@ -1,14 +1,5 @@
 package info.novatec.testit.livingdoc.confluence.actions.server;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.ResourceBundle;
-
-import com.atlassian.confluence.spaces.actions.AbstractSpaceAction;
-import com.atlassian.confluence.velocity.htmlsafe.HtmlSafe;
-
 import info.novatec.testit.livingdoc.confluence.velocity.ConfluenceLivingDoc;
 import info.novatec.testit.livingdoc.server.LivingDocServerException;
 import info.novatec.testit.livingdoc.server.LivingDocServerService;
@@ -18,6 +9,15 @@ import info.novatec.testit.livingdoc.server.domain.Repository;
 import info.novatec.testit.livingdoc.server.domain.SystemUnderTest;
 import info.novatec.testit.livingdoc.server.rpc.RpcServerService;
 import info.novatec.testit.livingdoc.util.I18nUtil;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import com.atlassian.confluence.spaces.actions.AbstractSpaceAction;
+import com.atlassian.confluence.velocity.htmlsafe.HtmlSafe;
 
 
 @SuppressWarnings("serial")
@@ -73,8 +73,9 @@ public class LivingDocServerAction extends AbstractSpaceAction {
     }
 
     public String getUrl() {
-        if (url != null)
+        if (url != null) {
             return url;
+        }
         url = getNotNullProperty(ServerPropertiesManager.URL);
         return url;
     }
@@ -96,8 +97,9 @@ public class LivingDocServerAction extends AbstractSpaceAction {
     }
 
     public Repository getRegisteredRepository() throws LivingDocServerException {
-        if (registeredRepository != null)
+        if (registeredRepository != null) {
             return registeredRepository;
+        }
         registeredRepository = getService().getRegisteredRepository(getHomeRepository());
         return registeredRepository;
     }
@@ -107,8 +109,9 @@ public class LivingDocServerAction extends AbstractSpaceAction {
     }
 
     public Repository getHomeRepository() throws LivingDocServerException {
-        if (homeRepository != null)
+        if (homeRepository != null) {
             return homeRepository;
+        }
         if (key == null) {
             homeRepository = Repository.newInstance("UNKNOWN_UID");
         } else {
@@ -119,13 +122,16 @@ public class LivingDocServerAction extends AbstractSpaceAction {
     }
 
     public List<SystemUnderTest> getSystemUnderTests() {
-        if ( ! isServerSetupComplete())
+        if ( ! isServerSetupComplete()) {
             return new ArrayList<SystemUnderTest>();
+        }
 
         try {
-            if (projectName == null)
-                if (systemUnderTests != null)
+            if (projectName == null) {
+                if (systemUnderTests != null) {
                     return systemUnderTests;
+                }
+            }
             systemUnderTests = ldUtil.getLDServerService().getSystemUnderTestsOfProject(projectName);
         } catch (LivingDocServerException e) {
             addActionError(e.getId());
@@ -135,10 +141,12 @@ public class LivingDocServerAction extends AbstractSpaceAction {
     }
 
     public boolean isRegistered() {
-        if (isRegistered != null)
+        if (isRegistered != null) {
             return isRegistered;
-        if ( ! isServerReady())
+        }
+        if ( ! isServerReady()) {
             return false;
+        }
 
         try {
             getRegisteredRepository();
@@ -170,15 +178,16 @@ public class LivingDocServerAction extends AbstractSpaceAction {
         return getText("livingdoc.registration.newproject");
     }
 
-    private String getNotNullProperty(String key) {
-        String value = ldUtil.getPageProperty(key, getIdentifier());
+    private String getNotNullProperty(String propertyKey) {
+        String value = ldUtil.getPageProperty(propertyKey, getIdentifier());
         return value == null ? "" : value;
     }
 
     @Override
     public String getSpaceKey() {
-        if (spaceKey == null)
+        if (spaceKey == null) {
             spaceKey = key;
+        }
         return spaceKey;
     }
 
@@ -190,16 +199,16 @@ public class LivingDocServerAction extends AbstractSpaceAction {
     /**
      * Custom I18n. Based on WebWork i18n.
      * 
-     * @param key Key
+     * @param propertyKey Key
      * @return the i18nzed message. If none found key is returned.
      */
     @Override
     @HtmlSafe
-    public String getText(String key) {
-        String text = super.getText(key);
+    public String getText(String propertyKey) {
+        String text = super.getText(propertyKey);
 
-        if (text.equals(key)) {
-            text = I18nUtil.getText(key, getResourceBundle());
+        if (text.equals(propertyKey)) {
+            text = I18nUtil.getText(propertyKey, getResourceBundle());
         }
 
         return text;
@@ -207,11 +216,11 @@ public class LivingDocServerAction extends AbstractSpaceAction {
 
     @Override
     @HtmlSafe
-    public String getText(String key, Object[] args) {
-        String text = super.getText(key, args);
+    public String getText(String propertyKey, Object[] args) {
+        String text = super.getText(propertyKey, args);
 
-        if (text.equals(key)) {
-            text = I18nUtil.getText(key, getResourceBundle(), args);
+        if (text.equals(propertyKey)) {
+            text = I18nUtil.getText(propertyKey, getResourceBundle(), args);
         }
 
         return text;
@@ -233,8 +242,9 @@ public class LivingDocServerAction extends AbstractSpaceAction {
     }
 
     public LinkedList<Project> getProjects() {
-        if (projects != null)
+        if (projects != null) {
             return projects;
+        }
         try {
             projects = new LinkedList<Project>(getService().getAllProjects());
             projectName = projectName == null ? projects.iterator().next().getName() : projectName;

--- a/livingdoc-confluence5-plugin/src/main/resources/atlassian-plugin.xml
+++ b/livingdoc-confluence5-plugin/src/main/resources/atlassian-plugin.xml
@@ -447,6 +447,16 @@
        		<action name="RemoveFileSystem" class="info.novatec.testit.livingdoc.confluence.actions.server.FileSystemRegistration" method="doRemoveFileSystem">
            		<result name="success" type="velocity">/templates/livingdoc/configuration/filesystem/fileSystemPane.ajax.vm</result>
        		</action>
+ <!-- Actions managing General Settings -->
+            <action name="GetGeneralSettingsPane" class="info.novatec.testit.livingdoc.confluence.actions.server.ConfigurationAction">
+                <result name="success" type="velocity">/templates/livingdoc/configuration/settings/GeneralSettingsPane.ajax.vm</result>
+            </action>
+            <action name="EditSettings" class="info.novatec.testit.livingdoc.confluence.actions.server.ConfigurationAction">
+                <result name="success" type="velocity">/templates/livingdoc/configuration/settings/GeneralSettingsPane.ajax.vm</result>
+            </action>
+            <action name="UpdateSettings" class="info.novatec.testit.livingdoc.confluence.actions.server.ConfigurationAction">
+                <result name="success" type="velocity">/templates/livingdoc/configuration/settings/GeneralSettingsPane.ajax.vm</result>
+            </action>
 <!-- END -->
             <action name="LivingDocHeader" class="info.novatec.testit.livingdoc.confluence.actions.execution.HeaderExecutionAction" method="loadHeader">
                 <result name="success" type="velocity">/templates/livingdoc/confluence/execution/header.ajax.vm</result>

--- a/livingdoc-confluence5-plugin/src/main/resources/includes/js/ConfluenceActions.js
+++ b/livingdoc-confluence5-plugin/src/main/resources/includes/js/ConfluenceActions.js
@@ -29,6 +29,7 @@ LD.ConfluenceActions=
 		    data: preparedParams,
 		    dataType: 'html',
 		    error: obj.notifyError.bind(obj),
+			timeout: obj.params.executionTimeout*1000,
 		    complete: function(jqXHR) {
 		    	obj.notifyDoneWorking();
 		    	AJS.$('#' + elementId).html(jqXHR.responseText);
@@ -68,6 +69,10 @@ LD.ConfluenceActions=
 	editSutFixture:function(params) { this.confQuery("sutsPane_display", "/livingdoc/EditSutFixture.action", params); },
 	setSutAsDefault:function(params){ this.confQuery("sutsPane_display", "/livingdoc/SetAsDefault.action", params); },
 	getLdProjectPane:function(params){this.confQuery("tabs-project", "/livingdoc/GetLdProjectPane.action", params);},
+
+	editSettings:function(params){this.confQuery("tabs-settings", "/livingdoc/GetGeneralSettingsPane.action", params);},
+	updateSettings:function(params){this.confQuery("tabs-settings", "/livingdoc/UpdateSettings.action", params);},
+	getGeneralSettingsPane:function(params){this.confQuery("tabs-settings", "/livingdoc/GetGeneralSettingsPane.action", params);},
 	
 	getInstallWizardPane:function(params){this.confQuery("tabs-dbms-config", "/livingdoc/GetDbmsPane.action", params); },
 	changeInstallationType:function(params){ this.confQuery("dbmsChoice_display", "/livingdoc/ChangeInstallType.action", params); },

--- a/livingdoc-confluence5-plugin/src/main/resources/includes/js/conf-livingdoc.js
+++ b/livingdoc-confluence5-plugin/src/main/resources/includes/js/conf-livingdoc.js
@@ -63,13 +63,13 @@ var conf_livingDoc = new function()
 		if(!bulk){ bulk = this.registerBulk(bUID, actions); }
 		return bulk.registerList({decorator:'none', bulkUID:bUID, executionUID:exeUID, imgFile:imgFile, ctx:ctx});
 	};
-	this.registerSpecification=function(bUID, exeUID, ctx, imgFile, spaceKey, pageId, fieldId, actions, isMain)
+	this.registerSpecification=function(bUID, exeUID, ctx, imgFile, spaceKey, pageId, fieldId, executionTimeout, actions, isMain)
 	{
 		var bulk = this.getBulk(bUID);
 		if(!bulk){ bulk = this.registerBulk(bUID, actions); }
 		var list = bulk.getList(exeUID); 
 		if(!list){ list = bulk.registerList({decorator:'none', bulkUID:bUID, executionUID:exeUID, imgFile:imgFile, ctx:ctx}); }
-		return list.registerSpecification({spaceKey:spaceKey, pageId:pageId, fieldId:fieldId, isMain:isMain?true:false});
+		return list.registerSpecification({spaceKey:spaceKey, pageId:pageId, fieldId:fieldId,executionTimeout:executionTimeout, isMain:isMain?true:false});
 	};	
 
 	this.getBulk=function(bUID){ return this.bulks[bUID]; };

--- a/livingdoc-confluence5-plugin/src/main/resources/includes/js/livingdoc-util.js
+++ b/livingdoc-confluence5-plugin/src/main/resources/includes/js/livingdoc-util.js
@@ -57,6 +57,13 @@ LD.View =
 		target.attr('class', className);
 		target.val('');		
 	},
+	verifyNumericOnly: function(evt){
+		if (evt.which >= 48 && evt.which <= 57){return true;}    //Allows numerics
+		if (evt.keyCode >= 37 && evt.keyCode <=40){return true;} //Allows arrow keys
+		if (evt.keyCode == 8 || evt.keyCode == 46){return true;} //Allows backspace and delete
+		if (evt.keyCode == 9){return true;}                      //Allows tabulator
+		return false;
+	},
 	verifyKeyCode: function(evt){
 		var charCode = (evt.which) ? evt.which : evt.keyCode;
 		if (charCode == 95 || charCode == 33 || charCode == 32 || charCode == 8){ return true; }

--- a/livingdoc-confluence5-plugin/src/main/resources/includes/js/server-properties.js
+++ b/livingdoc-confluence5-plugin/src/main/resources/includes/js/server-properties.js
@@ -65,10 +65,10 @@ LDProperties.prototype =
 		var newProjectName = $('#newProjectName') ? $F('newProjectName') : 'NA'; 
 		this.action.register(this.createParams({id:id, repositoryName:$F('repositoryName'), projectName:$F('projectName'), newProjectName:newProjectName, username:$F('username'), pwd:$F('pwd')})); 
 	},
-	updateRegistration:function(id){ 
+	updateRegistration:function(id){
 		if($F('repositoryName') === ''){ return; }
-		var newProjectName = $('#newProjectName') ? $F('newProjectName') : 'NA'; 
-		this.action.updateRegistration(this.createParams({id:id, repositoryName:$F('repositoryName'), projectName:$F('projectName'), newProjectName:newProjectName, username:$F('username'), pwd:$F('pwd')})); 
+		var newProjectName = $('#newProjectName') ? $F('newProjectName') : 'NA';
+		this.action.updateRegistration(this.createParams({id:id, repositoryName:$F('repositoryName'), projectName:$F('projectName'), newProjectName:newProjectName, username:$F('username'), pwd:$F('pwd')}));
 	},
 	getSutsPane:function(id, projectName){ 
 		var readonly = $F('readonly') ? true : false;
@@ -140,6 +140,18 @@ LDProperties.prototype =
 	getLdProjectPane:function(){
 		AJS.tabs.change(AJS.$('a[href=#tabs-project]'));
 		this.action.getLdProjectPane(this.createParams({id:'none'}));
+	},
+
+	updateSettings:function(){
+		if($F('executionTimeout') === ''){ return; }
+		this.action.updateSettings(this.createParams({id:'none', executionTimeout:$F('executionTimeout'), editMode:false}));
+	},
+	editSettings:function(){
+		this.action.editSettings(this.createParams({id:'none', editMode:true}));
+	},
+	getGeneralSettingsPane:function(){
+		AJS.tabs.change(AJS.$('a[href=#tabs-settings]'));
+		this.action.getGeneralSettingsPane(this.createParams({id:'none', editMode:false}));
 	},
 
 	getDemoPane:function() {

--- a/livingdoc-confluence5-plugin/src/main/resources/info/novatec/testit/livingdoc/confluence/actions/server/ConfigurationAction.properties
+++ b/livingdoc-confluence5-plugin/src/main/resources/info/novatec/testit/livingdoc/confluence/actions/server/ConfigurationAction.properties
@@ -114,6 +114,11 @@ livingdoc.filesystem.done=Done
 livingdoc.filesystem.desc=You can add physical file directories as specification repositories.<br>These directories must be located on a shared drive so that they are accessible to LivingDoc server and external clients - such as the Eclipse plugin. <br />i.e: //{server-name}/{shared-name} 
 livingdoc.filesystem.project=Project:
 
+livingdoc.settings.title=LivingDoc General Settings
+livingdoc.settings.desc=These settings affects all registered LivingDoc Spaces.
+livingdoc.settings.executionTimeout=Execution timeout in seconds: <br>(default: 60, infinite: 0)
+livingdoc.settings.edit=Edit
+
 livingdoc.server.generalexeerror=A general error occured in the execution.
 livingdoc.server.configerror=The Client configuration is invalid.
 livingdoc.server.xmlrpcurlinvalid=The XML-RPC server context not found.

--- a/livingdoc-confluence5-plugin/src/main/resources/info/novatec/testit/livingdoc/confluence/actions/server/InstallationAction.properties
+++ b/livingdoc-confluence5-plugin/src/main/resources/info/novatec/testit/livingdoc/confluence/actions/server/InstallationAction.properties
@@ -23,6 +23,7 @@ livingdoc.install.dbms.init.failure=The initialization of the DBMS failed.
 livingdoc.install.tabmenu.dbms=Database
 livingdoc.install.tabmenu.runners=Runner
 livingdoc.install.tabmenu.ldproject=Project Management
+livingdoc.install.tabmenu.settings=General Settings
 livingdoc.install.tabmenu.fsregister=File System Registration
 
 livingdoc.install.tabmenu.demo=Demo Space

--- a/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/configuration/installation/livingDocInstall.vm
+++ b/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/configuration/installation/livingDocInstall.vm
@@ -17,25 +17,29 @@
 				<div id="tab-container" class="aui-tabs horizontal-tabs"">
 			        <ul class="tabs-menu">
 			            <li class="menu-item active-tab">
-			            	<a onclick="ldProperties.getDbmsConfigPane();"
+                            <a onclick="ldProperties.getDbmsConfigPane();"
 			            		href="#tabs-dbms-config">$action.getText('livingdoc.install.tabmenu.dbms')</a>
 			            </li>
 			            <li class="menu-item">
-			            	<a onclick="ldProperties.getRunnersPane();"
+                            <a onclick="ldProperties.getRunnersPane();"
 			            		href="#tabs-runner">$action.getText('livingdoc.install.tabmenu.runners')</a>
 			            </li>
 			            <li class="menu-item">
-			            	<a onclick="ldProperties.getLdProjectPane();"
+                            <a onclick="ldProperties.getLdProjectPane();"
 			            		href="#tabs-project">$action.getText('livingdoc.install.tabmenu.ldproject')</a>
-			                </li>
-			             <li class="menu-item">
-			            	<a onclick="ldProperties.getFileSystemRegistration();"	
+			            </li>
+                        <li class="menu-item">
+                            <a onclick="ldProperties.getGeneralSettingsPane();"
+                               href="#tabs-settings">$action.getText('livingdoc.install.tabmenu.settings')</a>
+                        </li>
+			            <li class="menu-item">
+                            <a onclick="ldProperties.getFileSystemRegistration();"
 			            		href="#tabs-file-system">$action.getText('livingdoc.install.tabmenu.fsregister')</a>
 			               </li>
-			             <li class="menu-item">
-			            	<a onclick="ldProperties.getDemoPane();"
+			            <li class="menu-item">
+							<a onclick="ldProperties.getDemoPane();"
 			            		href="#tabs-demo">$action.getText('livingdoc.install.tabmenu.demo')</a>
-			                </li>
+			            </li>
 			        </ul>
 		        	
 			        <div class="tabs-pane active-pane" id="tabs-dbms-config">
@@ -43,6 +47,7 @@
 			        </div>
 			        <div class="tabs-pane" id="tabs-runner"></div>
 			        <div class="tabs-pane" id="tabs-project"></div>
+            		<div class="tabs-pane" id="tabs-settings"></div>
 			        <div class="tabs-pane" id="tabs-file-system"></div>
 			        <div class="tabs-pane" id="tabs-demo"></div>
 

--- a/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/configuration/settings/GeneralSettingsPane.ajax.vm
+++ b/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/configuration/settings/GeneralSettingsPane.ajax.vm
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<meta name="decorator" content="none">
+	</head>
+	<body>
+		#parse('templates/livingdoc/configuration/settings/GeneralSettingsPane.vm')
+	</body>
+</html>

--- a/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/configuration/settings/GeneralSettingsPane.vm
+++ b/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/configuration/settings/GeneralSettingsPane.vm
@@ -1,0 +1,36 @@
+<div class="steptitle">
+    <h2>$action.getText('livingdoc.settings.title')</h2></div>
+#if($action.isServerReady)
+    #if(!$action.editMode)
+        <span id="registrationPane_register">
+            <button type="button" class="aui-button sp_configButtonRight" onclick="ldProperties.editSettings();">
+                <span class="aui-icon aui-icon-small aui-iconfont-add">Register</span> $action.getText('livingdoc.settings.edit')
+            </button>
+        </span>
+    #end
+#end
+#if (!$action.actionErrors.isEmpty() && !$errorDisplayed)
+	#set($errorDisplayed = true)
+    <div id="runnersPaneError_display"
+       class="aui-message error">
+       <p class="title">
+       		<span class="aui-icon icon-error"></span>
+           <strong>Error!</strong>
+       </p>
+       <p class="ldErrMsg">#foreach($error in $action.actionErrors)
+           $action.getText($error) #end</p>
+   </div>
+#end
+
+#if($action.isServerReady)
+	<p class="stepdesc">$action.getText('livingdoc.settings.desc')</p>
+	#if($action.readonly)<span id="readonly" style="display:none"></span>#end
+	<div id="greyBoxSettings" class="form-block greyboxfilled">
+        #if($action.editMode)
+            #parse('templates/livingdoc/configuration/settings/settingsEdit.vm')
+        #else
+            #parse('templates/livingdoc/configuration/settings/settings.vm')
+        #end
+
+	</div>
+#end

--- a/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/configuration/settings/settings.vm
+++ b/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/configuration/settings/settings.vm
@@ -1,0 +1,14 @@
+<div class="sp_configItemView">
+	<form class="aui long-label">
+		<fieldset>
+		    <div class="field-group">
+		        <label for="settingsPane_executionTimeout" class="sp_configSubTitle">
+		            $action.getText('livingdoc.settings.executionTimeout')
+		        </label>
+		        <span id="settingsPane_executionTimeout" class="field-value sp_configOutput" name="settingsPane_executionTimeout">
+					$action.executionTimeout
+		        </span>
+		    </div>
+	    </fieldset>
+    </form>
+</div>

--- a/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/configuration/settings/settingsEdit.vm
+++ b/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/configuration/settings/settingsEdit.vm
@@ -1,0 +1,22 @@
+<div class="sp_configItemView">
+    <form class="aui long-label">
+        <fieldset>
+            <div class="field-group">
+                <label for="executionTimeout" class="sp_configLabels">$action.getText('livingdoc.settings.executionTimeout')</label>
+                <input class="text sp_configInput" type="text" id="executionTimeout" name="executionTimeout" value="$!action.executionTimeout" size="15" class="sp_configInput" onkeypress="javascript:return LD.View.verifyNumericOnly(event);">
+            </div>
+            <div class="field-group">
+				<span id="settingsEdit_update">
+					<button type="button" class="aui-button aui-button-primary" onclick="ldProperties.updateSettings();">
+						$action.getText('livingdoc.registration.update')
+					</button>
+				</span>
+                <span id="settingsEdit_cancel">
+					<button type="button" class="aui-button aui-button-link" onclick="ldProperties.getGeneralSettingsPane();">
+						$action.getText('livingdoc.registration.cancel')
+					</button>
+				</span>
+            </div>
+        </fieldset>
+    </form>
+</div>

--- a/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/confluence/execution/header-execution.vm
+++ b/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/confluence/execution/header-execution.vm
@@ -1,4 +1,4 @@
-<script language="JavaScript" type="text/javascript">conf_livingDoc.registerSpecification('$action.bulkUID', '$action.executionUID', '$req.contextPath', '$req.contextPath/download/resources/info.novatec.testit.livingdoc.confluence.plugin:livingdoc.webactions/images/', '$action.spaceKey', '$action.page.id', '0', LD.ConfluenceActions, true);</script>
+<script language="JavaScript" type="text/javascript">conf_livingDoc.registerSpecification('$action.bulkUID', '$action.executionUID', '$req.contextPath', '$req.contextPath/download/resources/info.novatec.testit.livingdoc.confluence.plugin:livingdoc.webactions/images/', '$action.spaceKey', '$action.page.id', '0', '$action.executionTimeout', LD.ConfluenceActions, true);</script>
 <div width="100%">
 	<table class="conf_executionPane" cellpadding="0" cellspacing="0">
 		<tr>

--- a/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/confluence/execution/specification.vm
+++ b/livingdoc-confluence5-plugin/src/main/resources/templates/livingdoc/confluence/execution/specification.vm
@@ -1,4 +1,4 @@
-<script language="JavaScript" type="text/javascript">conf_livingDoc.registerSpecification('$action.bulkUID', '$action.executionUID', '$req.contextPath', '$req.contextPath/download/resources/info.novatec.testit.livingdoc.confluence.plugin:livingdoc.webactions/images/', '$aPage.spaceKey', '$aPage.id', '$fieldId', LD.ConfluenceActions);</script>
+<script language="JavaScript" type="text/javascript">conf_livingDoc.registerSpecification('$action.bulkUID', '$action.executionUID', '$req.contextPath', '$req.contextPath/download/resources/info.novatec.testit.livingdoc.confluence.plugin:livingdoc.webactions/images/', '$aPage.spaceKey', '$aPage.id', '$fieldId', '$action.executionTimeout', LD.ConfluenceActions);</script>
 <table id="conf_specification_${action.bulkUID}_${action.executionUID}_$fieldId" class="conf_specificationOutputTable" cellspacing="0" cellpadding="0">
 	<tr>
 		#set($bulletIndex = $fieldId + 1)


### PR DESCRIPTION
added menu tab for "General Settings" to plugin configuration;

added "Execution timeout" to General Settings;
- default 60 seconds
- 0 equals to no timeout
- changing value effects executions after reloading page

added verification for "Execution timeout";
- pressing invalid keys does not effect any changes to inputfield
- allowed keys: 0-9, backspace, delete, tabulator

improved code-style
